### PR TITLE
Update Ruby to 2.4.4 and migrate to CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,61 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/object_json_mapper
+    docker:
+      - image: circleci/ruby:2.4.4
+        environment:
+          BUNDLE_JOBS: 3
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+
+    steps:
+      - checkout
+
+      # Which version of bundler?
+      - run:
+          name: Which bundler?
+          command: bundle -v
+
+      # Restore bundle cache
+      - restore_cache:
+          keys:
+            - object_json_mapper-bundle-v2-{{ checksum "object_json_mapper.gemspec" }}
+            - object_json_mapper-bundle-v2-
+
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      # Store bundle cache
+      - save_cache:
+          key: object_json_mapper-bundle-v2-{{ checksum "object_json_mapper.gemspec" }}
+          paths:
+            - vendor/bundle
+
+      - run:
+          name: Setup Code Climate test-reporter
+          command: |
+            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+            chmod +x ./cc-test-reporter
+
+      # Run rspec in parallel
+      - type: shell
+        command: |
+          ./cc-test-reporter before-build
+
+          bundle exec rspec --profile 10 \
+                            --format RspecJunitFormatter \
+                            --out test_results/rspec.xml \
+                            --format progress \
+                            $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+
+          ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
+
+      # Save test results for timing analysis
+      - store_test_results:
+          path: test_results
+
+      # Save test coverage
+      - store_artifacts:
+          path: coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,15 @@
-/.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/
 /pkg/
 /spec/reports/
 /tmp/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+Gemfile.lock
+.ruby-version
+.ruby-gemset

--- a/object_json_mapper.gemspec
+++ b/object_json_mapper.gemspec
@@ -18,14 +18,16 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'awesome_print', '~> 1.7'
   spec.add_development_dependency 'bundler', '~> 1.12'
+  spec.add_development_dependency 'kaminari', '~> 0.17'
+  spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'pry-byebug', '~> 3.4'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'awesome_print', '~> 1.7'
-  spec.add_development_dependency 'pry', '~> 0.10'
+  spec.add_development_dependency 'rspec_junit_formatter'
+  spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock', '~> 2.3'
-  spec.add_development_dependency 'pry-byebug', '~> 3.4'
-  spec.add_development_dependency 'kaminari', '~> 0.17'
 
   spec.add_dependency 'activemodel', '>= 4.2'
   spec.add_dependency 'activesupport', '>= 4.2'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'object_json_mapper'
 require 'webmock/rspec'


### PR DESCRIPTION
CircleCI 2.0 supports only officially supported Ruby versions, which
means the current Ruby version for this project is unsupported. Due to a
compatibility conflict with the PHP/OpenSSL version that is installed on
the server, we cannot upgrade to 2.3.7, but have to move ahead to the
2.4 branch.